### PR TITLE
Remove dependency to ssh-agent plugin by switching to withCredentials

### DIFF
--- a/vars/cloneGit.groovy
+++ b/vars/cloneGit.groovy
@@ -32,16 +32,13 @@ def call(Map <String, ?> config = [:]) {
         node(POD_LABEL) {
           container('git') {
 
-            // For SSH private key authentication, try the sshagent step from the SSH Agent plugin.
-            sshagent(credentials: [config.git_user_ssh_key]) {
+            gitUtils.fixNonRootUserIdInContainer()
 
-              gitUtils.fixNonRootUserIdInContainer()
+            gitUtils.configGitAuthor(config)
 
-              gitUtils.configGitAuthor(config)
+            gitUtils.clone(config)
 
-              gitUtils.clone(config)
 
-            }
           }
         }
       }

--- a/vars/openPR.groovy
+++ b/vars/openPR.groovy
@@ -32,22 +32,18 @@ def call(Map <String, ?> config = [:]) {
         node(POD_LABEL) {
           container('git') {
 
-            // For SSH private key authentication, try the sshagent step from the SSH Agent plugin.
-            sshagent(credentials: [config.git_user_ssh_key]) {
+            gitUtils.fixNonRootUserIdInContainer()
 
-              gitUtils.fixNonRootUserIdInContainer()
+            gitUtils.configGitAuthor(config)
 
-              gitUtils.configGitAuthor(config)
+            gitUtils.clone(config)
 
-              gitUtils.clone(config)
+            gitUtils.gpgSetupForGit(config)
 
-              gitUtils.gpgSetupForGit(config)
+            gitUtils.commitAndPush(config)
 
-              gitUtils.commitAndPush(config)
+            gitUtils.openPR(config)
 
-              gitUtils.openPR(config)
-
-            }
           }
         }
       }


### PR DESCRIPTION
Rather than relying on sshagent, which is problematic to work in containers (https://issues.jenkins.io/browse/JENKINS-42582, https://github.com/jenkinsci/kubernetes-plugin/pull/331, https://issues.jenkins.io/browse/JENKINS-28279,https://issues.jenkins.io/browse/JENKINS-54114), we switch to the more straightforward / less magic approach of `withCredentials`, in combination with `GIT_SSH_COMMAND="ssh -i $SSH_KEY"`

Besides the above problems, this is also the recommended approach on the docs of the ssh-agent plugin itself: https://github.com/jenkinsci/ssh-agent-plugin/commit/b9e17150f1695ef2e5ecbfa9c01b1199a25ececc