### PR TITLE
Fix missing `~.ssh` folder

### DIFF
--- a/vars/tagGit.groovy
+++ b/vars/tagGit.groovy
@@ -33,6 +33,7 @@ def call(Map <String, ?> config = [:]) {
           container('git') {
 
             if(config.ssh_key_type){
+              mkdir -p ~/.ssh/
               sh "ssh-keyscan -t ${config.ssh_key_type} ${config.git_server} >> ~/.ssh/known_hosts"
             }
             


### PR DESCRIPTION
as per build error in https://main-jenkins-csb-3scaleprod.apps.ocp-c1.prod.psi.redhat.com/job/common/job/release-ship/job/upstream_tags/27/console